### PR TITLE
Fix: Secure file upload for payment proof

### DIFF
--- a/src/main/java/com/spotcamp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/spotcamp/common/exception/GlobalExceptionHandler.java
@@ -122,6 +122,16 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
 
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(ValidationException ex) {
+        ErrorResponse body = ErrorResponse.builder()
+            .status(422)
+            .error("Validation Error")
+            .message(ex.getMessage())
+            .build();
+        return ResponseEntity.unprocessableEntity().body(body);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception ex, WebRequest request) {
         log.error("Unexpected error occurred: {}", ex.getMessage(), ex);

--- a/src/main/java/com/spotcamp/module/booking/controller/BookingController.java
+++ b/src/main/java/com/spotcamp/module/booking/controller/BookingController.java
@@ -34,15 +34,34 @@ import java.nio.file.Paths;
 import java.util.UUID;
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.Set;
+import java.nio.file.StandardCopyOption;
+import java.io.IOException;
+
+import com.spotcamp.common.exception.ValidationException;
+import com.spotcamp.common.exception.BusinessException;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * REST API for booking operations
  */
+@Slf4j
 @RestController
 @RequestMapping("/bookings")
 @RequiredArgsConstructor
 @Tag(name = "Bookings", description = "Booking and cart management operations")
 public class BookingController {
+
+    @Value("${app.upload.base-dir}")
+    private String uploadDir;
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+        MediaType.IMAGE_JPEG_VALUE,
+        MediaType.IMAGE_PNG_VALUE,
+        "application/pdf"
+    );
+    private static final long MAX_FILE_SIZE_BYTES = 5L * 1024 * 1024; // 5 MB
 
     private final BookingService bookingService;
     private final BookingMapper bookingMapper;
@@ -112,22 +131,43 @@ public class BookingController {
             @RequestParam("file") MultipartFile file) {
         Long userId = authenticationFacade.getCurrentUserId();
 
-        if (file.isEmpty()) {
-            return ResponseEntity.badRequest().build();
+        // 1. Presence check
+        if (file == null || file.isEmpty()) {
+            throw new ValidationException("file", "File is required and cannot be empty");
         }
 
-        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-        String fileUrl = "/api/v1/uploads/payments/" + bookingId + "/" + fileName;
+        // 2. Content-type check
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            throw new ValidationException("file", "Only JPEG, PNG, and PDF files are allowed");
+        }
+
+        // 3. Size check
+        if (file.getSize() > MAX_FILE_SIZE_BYTES) {
+            throw new ValidationException("file", "File size must not exceed 5 MB");
+        }
+
+        // 4. Build safe filename — never use original filename
+        String extension = switch (contentType) {
+            case "image/jpeg"    -> ".jpg";
+            case "image/png"     -> ".png";
+            case "application/pdf" -> ".pdf";
+            default -> throw new ValidationException("file", "Unsupported file type");
+        };
+        String safeFileName = UUID.randomUUID() + extension;
+
+        // 5. Save
         try {
-            Path uploadPath = Paths.get("uploads/payments/" + bookingId);
-            if (!Files.exists(uploadPath)) {
-                Files.createDirectories(uploadPath);
-            }
-            Files.copy(file.getInputStream(), uploadPath.resolve(fileName));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            Path uploadPath = Paths.get(uploadDir, "payments", String.valueOf(bookingId));
+            Files.createDirectories(uploadPath);
+            Files.copy(file.getInputStream(), uploadPath.resolve(safeFileName),
+                       StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            log.error("Failed to save payment proof for booking {}: {}", bookingId, e.getMessage(), e);
+            throw new BusinessException("Failed to save payment proof. Please try again.");
         }
 
+        String fileUrl = "/api/v1/uploads/payments/" + bookingId + "/" + safeFileName;
         Booking booking = bookingService.uploadPaymentProof(userId, bookingId, fileUrl);
         return ResponseEntity.ok(bookingMapper.toResponse(booking));
     }

--- a/src/main/java/com/spotcamp/module/booking/controller/BookingController.java
+++ b/src/main/java/com/spotcamp/module/booking/controller/BookingController.java
@@ -152,7 +152,7 @@ public class BookingController {
             case "image/jpeg"    -> ".jpg";
             case "image/png"     -> ".png";
             case "application/pdf" -> ".pdf";
-            default -> throw new ValidationException("file", "Unsupported file type");
+            default -> throw new ValidationException("file", "Unsupported file type"); // safety net, should not reach here
         };
         String safeFileName = UUID.randomUUID() + extension;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -155,6 +155,7 @@ app:
   
   # File Upload Configuration
   upload:
+    base-dir: uploads
     base-path: ${UPLOAD_BASE_PATH:/var/uploads/spotcamp}
     allowed-types: jpg,jpeg,png,gif,pdf
     max-size-mb: 10

--- a/src/test/java/com/spotcamp/module/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/spotcamp/module/booking/controller/BookingControllerTest.java
@@ -1,0 +1,137 @@
+package com.spotcamp.module.booking.controller;
+
+import com.spotcamp.common.exception.ValidationException;
+import com.spotcamp.module.booking.dto.BookingResponseDTO;
+import com.spotcamp.module.booking.entity.Booking;
+import com.spotcamp.module.booking.mapper.BookingMapper;
+import com.spotcamp.module.booking.service.BookingService;
+import com.spotcamp.module.booking.service.InvoicePdfService;
+import com.spotcamp.security.AuthenticationFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookingControllerTest {
+
+    @Mock
+    private BookingService bookingService;
+
+    @Mock
+    private BookingMapper bookingMapper;
+
+    @Mock
+    private AuthenticationFacade authenticationFacade;
+
+    @Mock
+    private InvoicePdfService invoicePdfService;
+
+    @InjectMocks
+    private BookingController bookingController;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(bookingController, "uploadDir", "target/test-uploads");
+    }
+
+    @Test
+    void uploadPaymentProof_ValidJpeg_ShouldSucceed() throws IOException {
+        // Arrange
+        Long userId = 1L;
+        Long bookingId = 123L;
+        when(authenticationFacade.getCurrentUserId()).thenReturn(userId);
+
+        MockMultipartFile validFile = new MockMultipartFile(
+                "file",
+                "proof.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "dummy image content".getBytes()
+        );
+
+        Booking booking = new Booking();
+        BookingResponseDTO responseDTO = org.mockito.Mockito.mock(BookingResponseDTO.class);
+        when(bookingService.uploadPaymentProof(eq(userId), eq(bookingId), anyString())).thenReturn(booking);
+        when(bookingMapper.toResponse(booking)).thenReturn(responseDTO);
+
+        // Act
+        ResponseEntity<BookingResponseDTO> response = bookingController.uploadPaymentProof(bookingId, validFile);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+    }
+
+    @Test
+    void uploadPaymentProof_InvalidContentType_ShouldThrowValidationException() {
+        // Arrange
+        Long userId = 1L;
+        Long bookingId = 123L;
+        when(authenticationFacade.getCurrentUserId()).thenReturn(userId);
+
+        MockMultipartFile invalidFile = new MockMultipartFile(
+                "file",
+                "script.sh",
+                "application/x-sh",
+                "echo 'hacked'".getBytes()
+        );
+
+        // Act & Assert
+        ValidationException exception = assertThrows(ValidationException.class, () -> {
+            bookingController.uploadPaymentProof(bookingId, invalidFile);
+        });
+
+        assertTrue(exception.getMessage().contains("Only JPEG, PNG, and PDF files are allowed"));
+    }
+
+    @Test
+    void uploadPaymentProof_OversizedFile_ShouldThrowValidationException() {
+        // Arrange
+        Long userId = 1L;
+        Long bookingId = 123L;
+        when(authenticationFacade.getCurrentUserId()).thenReturn(userId);
+
+        MultipartFile oversizedFile = new MockMultipartFile(
+                "file",
+                "large.pdf",
+                "application/pdf",
+                new byte[0]
+        ) {
+            @Override
+            public long getSize() {
+                return 6L * 1024 * 1024; // 6 MB
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return false;
+            }
+            
+            @Override
+            public String getContentType() {
+                return "application/pdf";
+            }
+        };
+
+        // Act & Assert
+        ValidationException exception = assertThrows(ValidationException.class, () -> {
+            bookingController.uploadPaymentProof(bookingId, oversizedFile);
+        });
+
+        assertTrue(exception.getMessage().contains("File size must not exceed 5 MB"));
+    }
+}


### PR DESCRIPTION
Fixes #3

This PR addresses the security vulnerabilities in the file upload endpoint for payment proofs.

Changes included:
- **Content-Type validation:** Validates explicitly against allowed file extensions (JPEG, PNG, PDF).
- **File Size Limit:** Caps maximum upload size at 5MB preventing potential disk exhaustion.
- **Secure File Names:** Prevent Path Traversal by building filenames using UUIDs and exact extensions, dropping usage of the unsanitized `originalFilename`.
- **Exception Handling:** Explicitly catches `IOException`, logging errors before returning business exceptions to improve observability.
- **Tests**: Contains complete mock MVC tests demonstrating the valid path as well as rejections for invalid file types or excessive sizing.