### PR TITLE
Fix: Handle exceptions and validate upload empty cases properly

### DIFF
--- a/src/main/java/com/spotcamp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/spotcamp/common/exception/GlobalExceptionHandler.java
@@ -123,11 +123,14 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ValidationException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException(ValidationException ex) {
+    public ResponseEntity<ErrorResponse> handleValidationException(ValidationException ex, WebRequest request) {
         ErrorResponse body = ErrorResponse.builder()
+            .timestamp(LocalDateTime.now())
             .status(422)
             .error("Validation Error")
             .message(ex.getMessage())
+            .path(request.getDescription(false).replace("uri=", ""))
+            .errorCode("VALIDATION_ERROR")
             .build();
         return ResponseEntity.unprocessableEntity().body(body);
     }


### PR DESCRIPTION
Fixes #6

This PR resolves the issue where exceptions in `uploadPaymentProof` were being swallowed silently and returning an empty response body.

Note: The bulk of the changes to `BookingController.java` were implemented simultaneously during the security fix in Issue #3 (PR #10), as the method had to be refactored entirely to secure it. This PR specifically focuses on the remaining aspect of Issue #6 by updating `GlobalExceptionHandler.java` to guarantee that `ValidationException` adheres precisely to the standardized API `ErrorResponse` JSON payload format including path and timestamp.