### PR TITLE
Fix: CORS configuration for credentials mode

### DIFF
--- a/src/main/java/com/spotcamp/security/SecurityConfig.java
+++ b/src/main/java/com/spotcamp/security/SecurityConfig.java
@@ -130,11 +130,27 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:*", "https://*.campsite.com"));
+        configuration.setAllowedOriginPatterns(Arrays.asList(
+            "http://localhost:*", 
+            "https://*.campsite.com", 
+            "https://spotcamp.id"
+        ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowedHeaders(Arrays.asList(
+            "Authorization",
+            "Content-Type",
+            "Accept",
+            "X-Requested-With",
+            "Cache-Control",
+            "Origin"
+        ));
+        configuration.setExposedHeaders(Arrays.asList(
+            "Set-Cookie",
+            "Authorization",
+            "Content-Disposition"
+        ));
         configuration.setAllowCredentials(true);
-        configuration.setExposedHeaders(Arrays.asList("Set-Cookie"));
+        configuration.setMaxAge(3600L);
         
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
Fixes #7

This PR resolves the CORS bug preventing frontend requests from being processed when credentials mode is active.

Changes made in `SecurityConfig.java`:
- Removed `configuration.setAllowedHeaders(Arrays.asList("*"))` which violates the CORS spec when `allowCredentials` is true.
- Explicitly set the `AllowedHeaders` to a safe list: `Authorization`, `Content-Type`, `Accept`, `X-Requested-With`, `Cache-Control`, `Origin`.
- Exposed necessary headers to the frontend: `Set-Cookie`, `Authorization`, `Content-Disposition`.
- Updated origins to explicitly use `setAllowedOriginPatterns` to support credential inclusion safely.
- Added `setMaxAge(3600L)` to cache preflight requests and improve client performance.