### PR TITLE
refactor(inventory): move bundle helper classes to dto package

### DIFF
--- a/src/main/java/com/spotcamp/module/inventory/controller/BundleController.java
+++ b/src/main/java/com/spotcamp/module/inventory/controller/BundleController.java
@@ -1,6 +1,8 @@
 package com.spotcamp.module.inventory.controller;
 
 import com.spotcamp.module.inventory.dto.BundleDefinitionDTO;
+import com.spotcamp.module.inventory.dto.BundleAvailabilityResult;
+import com.spotcamp.module.inventory.dto.BundleComponentRequest;
 import com.spotcamp.module.inventory.dto.BundleRequestDTO;
 import com.spotcamp.module.inventory.entity.Bundle;
 import com.spotcamp.module.inventory.service.BundleService;
@@ -104,9 +106,9 @@ public class BundleController {
     ) {
         log.info("Creating new bundle: {}", request.getName());
         
-        List<BundleService.BundleComponentRequest> components = request.getComponents().stream()
+        List<BundleComponentRequest> components = request.getComponents().stream()
                 .map(comp -> {
-                    BundleService.BundleComponentRequest componentReq = new BundleService.BundleComponentRequest();
+                    BundleComponentRequest componentReq = new BundleComponentRequest();
                     componentReq.setProductId(comp.getProductId());
                     componentReq.setQuantity(comp.getQuantity());
                     return componentReq;
@@ -192,9 +194,9 @@ public class BundleController {
     ) {
         log.info("Updating bundle: {}", bundleId);
         
-        List<BundleService.BundleComponentRequest> components = request.getComponents().stream()
+        List<BundleComponentRequest> components = request.getComponents().stream()
                 .map(comp -> {
-                    BundleService.BundleComponentRequest componentReq = new BundleService.BundleComponentRequest();
+                    BundleComponentRequest componentReq = new BundleComponentRequest();
                     componentReq.setProductId(comp.getProductId());
                     componentReq.setQuantity(comp.getQuantity());
                     return componentReq;
@@ -276,7 +278,7 @@ public class BundleController {
     ) {
         log.debug("Checking availability for bundle: {} from {} to {}", bundleId, checkIn, checkOut);
         
-        BundleService.BundleAvailabilityResult result = bundleService.checkBundleAvailability(
+        BundleAvailabilityResult result = bundleService.checkBundleAvailability(
                 bundleId, checkIn, checkOut);
         
         Map<String, Object> response = Map.of(

--- a/src/main/java/com/spotcamp/module/inventory/controller/CampsiteBundleController.java
+++ b/src/main/java/com/spotcamp/module/inventory/controller/CampsiteBundleController.java
@@ -2,6 +2,7 @@ package com.spotcamp.module.inventory.controller;
 
 import com.spotcamp.security.UserPrincipal;
 import com.spotcamp.module.inventory.dto.BundleDefinitionDTO;
+import com.spotcamp.module.inventory.dto.BundleComponentRequest;
 import com.spotcamp.module.inventory.dto.BundleRequestDTO;
 import com.spotcamp.module.inventory.entity.Bundle;
 import com.spotcamp.module.inventory.service.BundleService;
@@ -87,9 +88,9 @@ public class CampsiteBundleController {
     ) {
         log.info("Create bundle for campsite: {} by user: {}", campsiteId, principal.getId());
 
-        List<BundleService.BundleComponentRequest> components = request.getComponents().stream()
+        List<BundleComponentRequest> components = request.getComponents().stream()
                 .map(comp -> {
-                    BundleService.BundleComponentRequest componentReq = new BundleService.BundleComponentRequest();
+                    BundleComponentRequest componentReq = new BundleComponentRequest();
                     componentReq.setProductId(comp.getProductId());
                     componentReq.setQuantity(comp.getQuantity());
                     return componentReq;

--- a/src/main/java/com/spotcamp/module/inventory/dto/BundleAvailabilityResult.java
+++ b/src/main/java/com/spotcamp/module/inventory/dto/BundleAvailabilityResult.java
@@ -1,0 +1,41 @@
+package com.spotcamp.module.inventory.dto;
+
+import java.util.List;
+
+public class BundleAvailabilityResult {
+    private boolean available;
+    private String message;
+    private List<UnavailableComponent> unavailableComponents;
+
+    public static BundleAvailabilityResult available() {
+        BundleAvailabilityResult result = new BundleAvailabilityResult();
+        result.available = true;
+        return result;
+    }
+
+    public static BundleAvailabilityResult unavailable(String message) {
+        BundleAvailabilityResult result = new BundleAvailabilityResult();
+        result.available = false;
+        result.message = message;
+        return result;
+    }
+
+    public static BundleAvailabilityResult unavailable(List<UnavailableComponent> components) {
+        BundleAvailabilityResult result = new BundleAvailabilityResult();
+        result.available = false;
+        result.unavailableComponents = components;
+        return result;
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public List<UnavailableComponent> getUnavailableComponents() {
+        return unavailableComponents;
+    }
+}

--- a/src/main/java/com/spotcamp/module/inventory/dto/BundleComponentRequest.java
+++ b/src/main/java/com/spotcamp/module/inventory/dto/BundleComponentRequest.java
@@ -1,0 +1,22 @@
+package com.spotcamp.module.inventory.dto;
+
+public class BundleComponentRequest {
+    private Long productId;
+    private Integer quantity;
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Long productId) {
+        this.productId = productId;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/spotcamp/module/inventory/dto/UnavailableComponent.java
+++ b/src/main/java/com/spotcamp/module/inventory/dto/UnavailableComponent.java
@@ -1,0 +1,13 @@
+package com.spotcamp.module.inventory.dto;
+
+import com.spotcamp.module.inventory.service.BundleService.UnavailabilityReason;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class UnavailableComponent {
+    private Long productId;
+    private String productName;
+    private UnavailabilityReason reason;
+}

--- a/src/main/java/com/spotcamp/module/inventory/service/BundleService.java
+++ b/src/main/java/com/spotcamp/module/inventory/service/BundleService.java
@@ -4,6 +4,9 @@ import com.spotcamp.common.exception.BusinessException;
 import com.spotcamp.common.exception.ResourceNotFoundException;
 import com.spotcamp.common.exception.ValidationException;
 import com.spotcamp.common.util.PageUtils;
+import com.spotcamp.module.inventory.dto.BundleAvailabilityResult;
+import com.spotcamp.module.inventory.dto.BundleComponentRequest;
+import com.spotcamp.module.inventory.dto.UnavailableComponent;
 import com.spotcamp.module.inventory.entity.Bundle;
 import com.spotcamp.module.inventory.entity.Product;
 import com.spotcamp.module.inventory.entity.ProductStatus;
@@ -374,57 +377,6 @@ public class BundleService {
             return UnavailabilityReason.ALREADY_BOOKED;
         }
         return UnavailabilityReason.INVALID_COMPONENT;
-    }
-
-    // Helper classes for bundle operations
-    public static class BundleComponentRequest {
-        private Long productId;
-        private Integer quantity;
-        
-        // Getters and setters
-        public Long getProductId() { return productId; }
-        public void setProductId(Long productId) { this.productId = productId; }
-        public Integer getQuantity() { return quantity; }
-        public void setQuantity(Integer quantity) { this.quantity = quantity; }
-    }
-
-    public static class BundleAvailabilityResult {
-        private boolean available;
-        private String message;
-        private List<UnavailableComponent> unavailableComponents;
-        
-        public static BundleAvailabilityResult available() {
-            BundleAvailabilityResult result = new BundleAvailabilityResult();
-            result.available = true;
-            return result;
-        }
-        
-        public static BundleAvailabilityResult unavailable(String message) {
-            BundleAvailabilityResult result = new BundleAvailabilityResult();
-            result.available = false;
-            result.message = message;
-            return result;
-        }
-        
-        public static BundleAvailabilityResult unavailable(List<UnavailableComponent> components) {
-            BundleAvailabilityResult result = new BundleAvailabilityResult();
-            result.available = false;
-            result.unavailableComponents = components;
-            return result;
-        }
-        
-        // Getters
-        public boolean isAvailable() { return available; }
-        public String getMessage() { return message; }
-        public List<UnavailableComponent> getUnavailableComponents() { return unavailableComponents; }
-    }
-
-    @lombok.Builder
-    @lombok.Data
-    public static class UnavailableComponent {
-        private Long productId;
-        private String productName;
-        private UnavailabilityReason reason;
     }
 
     public enum UnavailabilityReason {


### PR DESCRIPTION
## Summary
- extract `BundleComponentRequest`, `BundleAvailabilityResult`, and `UnavailableComponent` from `BundleService` into `com.spotcamp.module.inventory.dto`
- remove the three static inner classes from `BundleService`
- update all callers to use the new DTO classes instead of `BundleService.*` types

## Validation
- mvn clean compile -q
- mvn test -q

Closes #9
