### PR TITLE
refactor(config): consolidate upload base config

### DIFF
--- a/src/main/java/com/spotcamp/config/WebConfig.java
+++ b/src/main/java/com/spotcamp/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.spotcamp.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -10,9 +11,12 @@ import java.nio.file.Paths;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    @Value("${app.upload.base-dir:uploads}")
+    private String uploadBaseDir;
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        Path uploadPath = Paths.get("uploads").toAbsolutePath().normalize();
+        Path uploadPath = Paths.get(uploadBaseDir).toAbsolutePath().normalize();
         String uploadLocation = uploadPath.toUri().toString();
         if (!uploadLocation.endsWith("/")) {
             uploadLocation += "/";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,7 +159,6 @@ app:
     campsites-dir: ${app.upload.base-dir}/campsites
     maps-dir: ${app.upload.base-dir}/maps
     payments-dir: ${app.upload.base-dir}/payments
-    base-path: ${UPLOAD_BASE_PATH:/var/uploads/spotcamp}
     allowed-types: jpg,jpeg,png,gif,pdf
     max-size-mb: 10
   
@@ -382,4 +381,3 @@ app:
     environment: production
   upload:
     base-dir: /var/spotcamp/uploads
-    base-path: /data/uploads/spotcamp


### PR DESCRIPTION
## Summary
- remove duplicate `app.upload.base-path` property from `application.yml`
- keep `app.upload.base-dir` as the single source of truth for upload directory configuration
- update `WebConfig` resource handler to use `app.upload.base-dir` instead of hardcoded `uploads`

## Validation
- mvn clean test -q

Closes #13
