### PR TITLE
fix(upload): secure campsite and map file uploads

### DIFF
--- a/src/main/java/com/spotcamp/module/campsite/service/CampsiteService.java
+++ b/src/main/java/com/spotcamp/module/campsite/service/CampsiteService.java
@@ -5,6 +5,7 @@ import com.spotcamp.module.campsite.entity.*;
 import com.spotcamp.module.campsite.repository.*;
 import com.spotcamp.common.exception.BusinessException;
 import com.spotcamp.common.exception.ResourceNotFoundException;
+import com.spotcamp.common.exception.ValidationException;
 import com.spotcamp.common.util.CodeGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,7 +22,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -29,6 +33,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CampsiteService {
+    private static final Set<String> ALLOWED_IMAGE_CONTENT_TYPES = Set.of(
+            MediaType.IMAGE_JPEG_VALUE,
+            MediaType.IMAGE_PNG_VALUE,
+            MediaType.IMAGE_GIF_VALUE
+    );
 
     private final CampsiteRepository campsiteRepository;
     private final CampsiteImageRepository imageRepository;
@@ -186,8 +195,23 @@ public class CampsiteService {
         Campsite campsite = campsiteRepository.findByIdAndOwnerId(campsiteId, merchantId)
                 .orElseThrow(() -> new ResourceNotFoundException("Campsite", "id", campsiteId));
 
-        // Save file
-        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        if (file == null || file.isEmpty()) {
+            throw new ValidationException("file", "File is required and cannot be empty");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_IMAGE_CONTENT_TYPES.contains(contentType)) {
+            throw new ValidationException("file", "Only JPEG, PNG, and GIF files are allowed");
+        }
+
+        String extension = switch (contentType) {
+            case "image/jpeg" -> ".jpg";
+            case "image/png" -> ".png";
+            case "image/gif" -> ".gif";
+            default -> throw new ValidationException("file", "Unsupported file type");
+        };
+
+        String fileName = UUID.randomUUID() + extension;
         String fileUrl = "/api/v1/uploads/campsites/" + campsiteId + "/" + fileName;
 
         try {
@@ -195,7 +219,7 @@ public class CampsiteService {
             if (!Files.exists(uploadPath)) {
                 Files.createDirectories(uploadPath);
             }
-            Files.copy(file.getInputStream(), uploadPath.resolve(fileName));
+            Files.copy(file.getInputStream(), uploadPath.resolve(fileName), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             throw new BusinessException("Failed to upload image: " + e.getMessage());
         }

--- a/src/main/java/com/spotcamp/module/visualmap/controller/CampsiteMapController.java
+++ b/src/main/java/com/spotcamp/module/visualmap/controller/CampsiteMapController.java
@@ -30,11 +30,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -48,6 +50,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Tag(name = "Maps", description = "Visual Map Configuration and Availability")
 public class CampsiteMapController {
+    private static final Set<String> ALLOWED_IMAGE_CONTENT_TYPES = Set.of(
+            MediaType.IMAGE_JPEG_VALUE,
+            MediaType.IMAGE_PNG_VALUE,
+            MediaType.IMAGE_GIF_VALUE
+    );
 
     private final MapConfigurationService mapConfigService;
     private final SpotAvailabilityService spotAvailabilityService;
@@ -221,14 +228,25 @@ public class CampsiteMapController {
     ) {
         log.info("Upload map background for campsite: {} by user: {}", campsiteId, principal.getId());
 
-        // Validate file type
-        String contentType = image.getContentType();
-        if (contentType == null || !contentType.startsWith("image/")) {
+        if (image == null || image.isEmpty()) {
             return ResponseEntity.badRequest().build();
         }
 
-        // Save file
-        String fileName = UUID.randomUUID() + "_" + image.getOriginalFilename();
+        String contentType = image.getContentType();
+        if (contentType == null || !ALLOWED_IMAGE_CONTENT_TYPES.contains(contentType)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        String extension = switch (contentType) {
+            case "image/jpeg" -> ".jpg";
+            case "image/png" -> ".png";
+            case "image/gif" -> ".gif";
+            default -> null;
+        };
+        if (extension == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        String fileName = UUID.randomUUID() + extension;
         String fileUrl = "/api/v1/uploads/maps/" + campsiteId + "/" + fileName;
 
         try {
@@ -236,7 +254,7 @@ public class CampsiteMapController {
             if (!Files.exists(uploadPath)) {
                 Files.createDirectories(uploadPath);
             }
-            Files.copy(image.getInputStream(), uploadPath.resolve(fileName));
+            Files.copy(image.getInputStream(), uploadPath.resolve(fileName), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             log.error("Failed to upload image", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();


### PR DESCRIPTION
## Summary
- remove `getOriginalFilename()` usage from campsite and map image uploads
- generate safe filenames as `UUID + extension`, where extension is derived from validated content type
- add explicit image content-type validation for campsite/map uploads (`image/jpeg`, `image/png`, `image/gif`)
- use `StandardCopyOption.REPLACE_EXISTING` when saving uploaded files

## Validation
- mvn clean test -q

Closes #14
