### PR TITLE
ci: add backend pipeline with jacoco coverage gate

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,46 @@
+name: Backend CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build and run tests
+        run: mvn clean verify -q
+        env:
+          SPRING_PROFILES_ACTIVE: test
+
+      - name: Upload JaCoCo coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/
+          retention-days: 7
+
+      - name: Add coverage comment to PR
+        uses: madrapps/jacoco-report@v1.6.1
+        if: github.event_name == 'pull_request'
+        with:
+          paths: ${{ github.workspace }}/target/site/jacoco/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80
+          title: '## Test Coverage Report'
+          update-comment: true

--- a/pom.xml
+++ b/pom.xml
@@ -295,16 +295,51 @@
                 <version>0.8.13</version>
                 <executions>
                     <execution>
+                        <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>report</id>
-                        <phase>test</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.70</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                            <excludes>
+                                <exclude>com/spotcamp/config/**</exclude>
+                                <exclude>com/spotcamp/module/*/entity/**</exclude>
+                                <exclude>com/spotcamp/module/*/dto/**</exclude>
+                                <exclude>com/spotcamp/module/*/mapper/**</exclude>
+                                <exclude>com/spotcamp/client/**</exclude>
+                                <exclude>**/*Application.class</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: false


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow at `.github/workflows/backend-ci.yml`
  - runs on push to any branch and PR to `main`
  - sets up Java 25 (Temurin)
  - runs `mvn clean verify -q` with `SPRING_PROFILES_ACTIVE=test`
  - uploads JaCoCo report artifact (`target/site/jacoco/`)
  - posts PR coverage comment via `madrapps/jacoco-report`
- update JaCoCo Maven config in `pom.xml`
  - `prepare-agent`, `report` (verify phase), and `check` (verify phase)
  - enforce minimum `LINE` coverage 80% and `BRANCH` coverage 70%
  - add coverage excludes per requirement
- add `src/test/resources/application-test.yml` with H2 in-memory config

## Validation
- `SPRING_PROFILES_ACTIVE=test mvn clean verify -q` (fails as expected due current coverage baseline)
- JaCoCo check output:
  - lines covered ratio: `0.06` (min `0.80`)
  - branches covered ratio: `0.06` (min `0.70`)

Closes #22
